### PR TITLE
Prevent setLpa being called if no LPA being set

### DIFF
--- a/src/Opg/Lpa/DataModel/Lpa/StateChecker.php
+++ b/src/Opg/Lpa/DataModel/Lpa/StateChecker.php
@@ -40,7 +40,9 @@ class StateChecker {
      */
     public function __construct(Lpa $lpa = null)
     {
-        $this->setLpa($lpa);
+        if ($lpa) {
+            $this->setLpa($lpa);
+        }
     }
 
     /**


### PR DESCRIPTION
@NSmithUK Can we merge this change into master and tag it up so that I can include it in the composer file for the new Type form flow. This just allows us to use the FlowChecker even when there's no LPA set. Alternative is to hardcode the lpa/donor route for the specific case.