### PR TITLE
Revert "LPA-2293: Correspondence name must not be blank"

### DIFF
--- a/src/Opg/Lpa/DataModel/Lpa/Document/Correspondence.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Document/Correspondence.php
@@ -93,7 +93,6 @@ class Correspondence extends AbstractData
         ]);
 
         $metadata->addPropertyConstraints('name', [
-            new Assert\NotBlank,
             new Assert\Type([
                 'type' => '\Opg\Lpa\DataModel\Common\LongName'
             ]),


### PR DESCRIPTION
Reverts ministryofjustice/opg-lpa-datamodels#30