### PR TITLE
Remove time callbacks for onArray()

### DIFF
--- a/src/Opg/Lpa/DataModel/AbstractData.php
+++ b/src/Opg/Lpa/DataModel/AbstractData.php
@@ -240,26 +240,22 @@ abstract class AbstractData implements AccessorInterface, JsonSerializable, Vali
     /**
      * Returns $this as an array, propagating to all properties that implement AccessorInterface.
      *
-     * @param callable|null $dateCallback
+     * @param bool $retainDateTimeInstances
      * @return array
      */
-    public function toArray(callable $dateCallback = null)
+    public function toArray(bool $retainDateTimeInstances = false)
     {
         $values = get_object_vars($this);
 
         foreach ($values as $k => $v) {
-            if ($v instanceof DateTime) {
-                if (is_callable($dateCallback)) {
-                    $values[$k] = call_user_func($dateCallback, $v);
-                } else {
-                    //  Get the value as a normal datetime string
-                    $values[$k] = $v->format('Y-m-d\TH:i:s.uO'); // ISO8601 including microseconds
-                }
+            if ($v instanceof DateTime && !$retainDateTimeInstances) {
+                //  Get the value as a normal datetime string
+                $values[$k] = $v->format('Y-m-d\TH:i:s.uO'); // ISO8601 including microseconds
             }
 
             // Recursively build this array...
             if ($v instanceof AccessorInterface) {
-                $values[$k] = $v->toArray($dateCallback);
+                $values[$k] = $v->toArray($retainDateTimeInstances);
             }
 
             // If the value is an array, check if it contains instances of AccessorInterface...
@@ -267,7 +263,7 @@ abstract class AbstractData implements AccessorInterface, JsonSerializable, Vali
                 // If so, map them...
                 foreach ($v as $a => $b) {
                     if ($b instanceof AccessorInterface) {
-                        $values[$k][$a] = $b->toArray($dateCallback);
+                        $values[$k][$a] = $b->toArray($retainDateTimeInstances);
                     }
                 }
             }

--- a/src/Opg/Lpa/DataModel/AccessorInterface.php
+++ b/src/Opg/Lpa/DataModel/AccessorInterface.php
@@ -43,10 +43,10 @@ interface AccessorInterface
     /**
      * Returns an array representation of $this instance.
      *
-     * @param callable|null $dateCallback
+     * @param bool $retainDateTimeInstances
      * @return array
      */
-    public function toArray(callable $dateCallback = null);
+    public function toArray(bool $retainDateTimeInstances = false);
 
     /**
      * Returns an JSON representation of $this instance.

--- a/src/Opg/Lpa/DataModel/Lpa/Document/Attorneys/Human.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Document/Attorneys/Human.php
@@ -64,9 +64,9 @@ class Human extends AbstractAttorney
         return parent::map($property, $v);
     }
 
-    public function toArray(callable $dateCallback = null)
+    public function toArray(bool $retainDateTimeInstances = false)
     {
-        return array_merge(parent::toArray($dateCallback), [
+        return array_merge(parent::toArray($retainDateTimeInstances), [
             'type' => 'human'
         ]);
     }

--- a/src/Opg/Lpa/DataModel/Lpa/Document/Attorneys/TrustCorporation.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Document/Attorneys/TrustCorporation.php
@@ -56,9 +56,9 @@ class TrustCorporation extends AbstractAttorney
         ]);
     }
 
-    public function toArray(callable $dateCallback = null)
+    public function toArray(bool $retainDateTimeInstances = false)
     {
-        return array_merge(parent::toArray($dateCallback), [
+        return array_merge(parent::toArray($retainDateTimeInstances), [
             'type' => 'trust'
         ]);
     }

--- a/src/Opg/Lpa/DataModel/Lpa/Lpa.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Lpa.php
@@ -246,25 +246,6 @@ class Lpa extends AbstractData
     }
 
     /**
-     * @param callable|null $dateCallback
-     * @return array
-     */
-    public function toArray(callable $dateCallback = null)
-    {
-        $data = parent::toArray($dateCallback);
-
-        //  If a date callback was used then convert the id value to _id
-        if (is_callable($dateCallback)) {
-            // Rename 'id' to '_id' (keeping it at the beginning of the array)
-            $data = ['_id' => $data['id']] + $data;
-
-            unset($data['id']);
-        }
-
-        return $data;
-    }
-
-    /**
      * Return an abbreviated (summary) version of the LPA.
      *
      * @return array

--- a/src/Opg/Lpa/DataModel/User/User.php
+++ b/src/Opg/Lpa/DataModel/User/User.php
@@ -134,25 +134,6 @@ class User extends AbstractData
     }
 
     /**
-     * @param callable|null $dateCallback
-     * @return array
-     */
-    public function toArray(callable $dateCallback = null)
-    {
-        $data = parent::toArray($dateCallback);
-
-        //  If a date callback was used then convert the id value to _id
-        if (is_callable($dateCallback)) {
-            // Rename 'id' to '_id' (keeping it at the beginning of the array)
-            $data = ['_id' => $data['id']] + $data;
-
-            unset($data['id']);
-        }
-
-        return $data;
-    }
-
-    /**
      * @return string
      */
     public function getId(): string

--- a/tests/OpgTest/Lpa/DataModel/Lpa/LpaTest.php
+++ b/tests/OpgTest/Lpa/DataModel/Lpa/LpaTest.php
@@ -46,11 +46,9 @@ class LpaTest extends TestCase
     {
         $lpa = FixturesData::getHwLpa();
 
-        $lpaArray = $lpa->toArray(function (DateTime $dateTime) {
-            //  Dummy callable
-        });
+        $lpaArray = $lpa->toArray();
 
-        $this->assertEquals($lpa->get('id'), $lpaArray['_id']);
+        $this->assertEquals($lpa->get('id'), $lpaArray['id']);
     }
 
     public function testAbbreviatedToArray()

--- a/tests/OpgTest/Lpa/DataModel/User/UserTest.php
+++ b/tests/OpgTest/Lpa/DataModel/User/UserTest.php
@@ -40,11 +40,9 @@ class UserTest extends TestCase
     {
         $user = FixturesData::getUser();
 
-        $lpaArray = $user->toArray(function (DateTime $dateTime) {
-            //  Dummy callable
-        });
+        $lpaArray = $user->toArray();
 
-        $this->assertEquals($user->get('id'), $lpaArray['_id']);
+        $this->assertEquals($user->get('id'), $lpaArray['id']);
     }
 
     public function testGetsAndSets()


### PR DESCRIPTION
Replaced with a bool, allowing times to be returned as either ISO8601 strings (default), or PHP DateTime instances.

DataLayer implementations are now responsible for encoding dates for their own implementation.