### PR TITLE
Improvements to prepare for supporting PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "minimum-stability": "stable",
     "license": "MIT",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 | ^8.0",
         "symfony/validator": "^4.2",
         "egulias/email-validator": "~1.2"
     },

--- a/src/Opg/Lpa/DataModel/AbstractData.php
+++ b/src/Opg/Lpa/DataModel/AbstractData.php
@@ -122,7 +122,7 @@ abstract class AbstractData implements AccessorInterface, JsonSerializable, Vali
         }
 
         //  If this value has a toDateTime method then call that here
-        if (method_exists($value, 'toDateTime')) {
+        if ((is_string($value) || is_object($value)) && method_exists($value, 'toDateTime')) {
             $value = $value->toDateTime();
         }
 

--- a/tests/phpunit
+++ b/tests/phpunit
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-../vendor/phpunit/phpunit/phpunit
+../vendor/phpunit/phpunit/phpunit $*


### PR DESCRIPTION
PHP 8 is more strict about calling functions on arguments of
the wrong type. Add an extra condition to guard against
calling method_exists() on values which aren't strings or objects.

Note that this doesn't require updating dependencies of the
library to PHP 8, as this change is backwards-compatible with PHP 7.

However, I have updated composer.json to mark the library as PHP 8.0
compatible after successfully running unit tests with 8.0.3.

After merging, suggest we tag the commit as 13.8 so it can be used in
projects (Make an LPA service-api is the first customer).