### PR TITLE
LPAL-449 Docblock fixes to enable successful service-front linting

### DIFF
--- a/src/Opg/Lpa/DataModel/Lpa/Document/Decisions/AbstractDecisions.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Document/Decisions/AbstractDecisions.php
@@ -66,7 +66,7 @@ abstract class AbstractDecisions extends AbstractData
     }
 
     /**
-     * @param string $how
+     * @param string|null $how
      * @return $this
      */
     public function setHow($how): AbstractDecisions
@@ -85,7 +85,7 @@ abstract class AbstractDecisions extends AbstractData
     }
 
     /**
-     * @param string $when
+     * @param string|null $when
      * @return $this
      */
     public function setWhen($when): AbstractDecisions
@@ -104,7 +104,7 @@ abstract class AbstractDecisions extends AbstractData
     }
 
     /**
-     * @param string $howDetails
+     * @param string|null $howDetails
      * @return $this
      */
     public function setHowDetails($howDetails): AbstractDecisions

--- a/src/Opg/Lpa/DataModel/Lpa/Document/Decisions/ReplacementAttorneyDecisions.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Document/Decisions/ReplacementAttorneyDecisions.php
@@ -51,7 +51,7 @@ class ReplacementAttorneyDecisions extends AbstractDecisions
     }
 
     /**
-     * @param string $whenDetails
+     * @param string|null $whenDetails
      * @return $this
      */
     public function setWhenDetails($whenDetails): ReplacementAttorneyDecisions

--- a/src/Opg/Lpa/DataModel/User/User.php
+++ b/src/Opg/Lpa/DataModel/User/User.php
@@ -191,9 +191,9 @@ class User extends AbstractData
     }
 
     /**
-     * @return Name
+     * @return Name|null
      */
-    public function getName(): Name
+    public function getName(): Name|null
     {
         return $this->name;
     }


### PR DESCRIPTION
The documentation for this project defines various methods as returning objects, but they may on occasion return null values. This causes lint errors when scanning service-front in the opg-lpa project.

Fix the docblocks so psalm (linter) is happy.

I'll tag this as a new version once merged and update opg-lpa. 