### PR TITLE
Ensure jsonSerialize method signature matches interface's

### DIFF
--- a/src/Opg/Lpa/DataModel/AbstractData.php
+++ b/src/Opg/Lpa/DataModel/AbstractData.php
@@ -277,7 +277,7 @@ abstract class AbstractData implements AccessorInterface, JsonSerializable, Vali
      *
      * @return mixed
      */
-    public function jsonSerialize(): mixed
+    public function jsonSerialize() : mixed
     {
         return $this->toArray();
     }


### PR DESCRIPTION
As the AbstractData class implements the JsonSerializable
interface, the jsonSerialize method implementation must have
a signature matching the one in the interface. This is not
a problem with PHP 8.0, but PHP 8.1 throws an exception
on encountering this.