### PR TITLE
Add guard clause to LPA Formatter

### DIFF
--- a/src/Opg/Lpa/DataModel/Lpa/Formatter.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Formatter.php
@@ -26,11 +26,16 @@ class Formatter
     /**
      * Formats either a set of passed instructions or preferences, ready to be output into the PDF.
      *
-     * @param string $text The text to be formatted
+     * @param string|null $text The text to be formatted
      * @return string
      */
-    public static function flattenInstructionsOrPreferences(string $text) : string
+    public static function flattenInstructionsOrPreferences(?string $text) : string
     {
+        /* Early return as null is permitted */
+        if (is_null($text)) {
+            return '';
+        }
+
         $content = '';
 
         foreach (explode("\r\n", trim($text)) as $contentLine) {


### PR DESCRIPTION
This method `flattenInstructionsOrPreferences` prevents an LPA object from being created if it doesn't contain instructions or preferences. The change removes the arbitrary need, and makes test fixtures shorter and easier to create.

Preferences or instructions may also be null according to the LPA data model, so there are no corresponding constraints.

There's currently no test coverage for the method, I will create a ticket to backfill.