### PR TITLE
LPAL-1033 Remove redundant validation on trust corporation fields

### DIFF
--- a/src/Opg/Lpa/DataModel/Lpa/Document/Attorneys/TrustCorporation.php
+++ b/src/Opg/Lpa/DataModel/Lpa/Document/Attorneys/TrustCorporation.php
@@ -16,13 +16,11 @@ class TrustCorporation extends AbstractAttorney
     /**
      * Field length constants
      */
-    const NAME_MIN_LENGTH = 1;
-    const NAME_MAX_LENGTH = 75;//40;
-    const NUMBER_MIN_LENGTH = 1;
-    const NUMBER_MAX_LENGTH = 75;//40;
+    const NAME_MAX_LENGTH = 75;
+    const NUMBER_MAX_LENGTH = 75;
 
     /**
-     * @var string The company name,
+     * @var string The company name.
      */
     protected $name;
 
@@ -39,7 +37,6 @@ class TrustCorporation extends AbstractAttorney
                 'type' => 'string'
             ]),
             new Assert\Length([
-                'min' => self::NAME_MIN_LENGTH,
                 'max' => self::NAME_MAX_LENGTH,
             ]),
         ]);
@@ -50,7 +47,6 @@ class TrustCorporation extends AbstractAttorney
                 'type' => 'string'
             ]),
             new Assert\Length([
-                'min' => self::NUMBER_MIN_LENGTH,
                 'max' => self::NUMBER_MAX_LENGTH,
             ]),
         ]);


### PR DESCRIPTION
Given that name and number are both fields, having a NotBlank constraint on these fields means they both have to have at least one character in them (so they are not blank). It's therefore redundant also having a minimum length 1 constraint, as that means the same thing as not blank in this context.

This allows us to remove an awkward work-around in Make which has to ignore duplicate error messages for the same validation issue (an empty string value in the name or number of a trust corporation).

(NB if anyone has a preference, we could remove the NotBlank constraint and keep the min length 1 constraint instead. However, this would require changes in Make, as we currently show error messages in response to the NotBlank constraint being violated, rather than the min length constraint.)